### PR TITLE
Sets the PATH when checking versions, while removing the local .bin folder from it

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ Add the following to your `package.json`:
 
 Where the `node` and `npm` engine properties specify a valid semver range for Node and npm versions, respectively.
 
-By default, if you have a `node` or `npm` binary installed locally to the project (thus ending up
+> By default, if you have a `node` or `npm` binary installed locally to the project (thus ending up
 in `./node_modules/.bin`), it will take precedence. If you wanto to check against a globally installed
 version instead, you can pass the `--ignore-local-bin` parameter (`-i` for short).
-
-It's worth noting that, while you may not be directly depending on `node` or `npm` packages, you may
+> 
+> It's worth noting that, while you may not be directly depending on `node` or `npm` packages, you may
 still have them as transitive dependencies - in any case, `ensure-node-env` will show which one is being considered
 and where it comes from.
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,15 @@ Add the following to your `package.json`:
     ...
 ```
 
-Where the `node` and `npm` engine properties specify a valid semver range for Node and npm version respectively.
+Where the `node` and `npm` engine properties specify a valid semver range for Node and npm versions, respectively.
 
+By default, if you have a `node` or `npm` binary installed locally to the project (thus ending up
+in `./node_modules/.bin`), it will take precedence. If you wanto to check against a globally installed
+version instead, you can pass the `--ignore-local-bin` parameter (`-i` for short).
+
+It's worth noting that, while you may not be directly depending on `node` or `npm` packages, you may
+still have them as transitive dependencies - in any case, `ensure-node-env` will show which one is being considered
+and where it comes from.
 
 ### Usage in libraries
 

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@
 import path from 'path';
 import semver from 'semver';
 import { execSync } from 'child_process';
+import { EOL } from 'os';
 
 const checkVersion = (engineName, command) => {
   let pkg = null;
@@ -30,12 +31,10 @@ const checkVersion = (engineName, command) => {
     // eslint-disable-next-line global-require, import/no-dynamic-require
     pkg = require(pkgJsonPath);
   } catch (e) {
-    console.log(`Unable to find ${pkgJsonPath}!  😱`);
-    console.log('');
+    console.log(`Unable to find ${pkgJsonPath}!  😱${EOL}`);
     console.log(
-      'Please ensure that this script is executed in the same directory.',
+      `Please ensure that this script is executed in the same directory.${EOL}`,
     );
-    console.log('');
     process.exit(1);
   }
 
@@ -45,9 +44,8 @@ const checkVersion = (engineName, command) => {
     expected = pkg.engines[engineName];
   } catch (e) {
     console.log(
-      `There is no engine named ${engineName} specified in package.json!  😱`,
+      `There is no engine named "${engineName}" specified in package.json!  😱${EOL}`,
     );
-    console.log('');
     process.exit(1);
   }
 
@@ -70,8 +68,7 @@ const checkVersion = (engineName, command) => {
       .replace('v', '')
       .trim();
   } catch (e) {
-    console.log(`Unable to get ${engineName} version!  😱`);
-    console.log('');
+    console.log(`Unable to get ${engineName} version!  😱${EOL}`);
     process.exit(1);
   }
 
@@ -79,22 +76,18 @@ const checkVersion = (engineName, command) => {
     const guide =
       'https://github.com/Skyscanner/ensure-node-env/blob/master/README.md#guide';
     console.log(
-      `Expected ${engineName} version to match ${expected}, but got ${version}.  😱`,
+      `Expected ${engineName} version to match ${expected}, but got ${version}.  😱${EOL}`,
     );
-    console.log('');
     console.log(
-      `Please follow Skyscanner's node environment guide (see ${guide}).`,
+      `Please follow Skyscanner's node environment guide (see ${guide}).${EOL}`,
     );
-    console.log('');
     process.exit(1);
   }
 };
 
-console.log('Checking node & npm versions...');
-console.log('');
+console.log(`Checking node & npm versions...${EOL}`);
 
 checkVersion('node', 'node --version');
 checkVersion('npm', 'npm -g --version');
 
-console.log('All good.  👍');
-console.log('');
+console.log(`${EOL}All good.  👍${EOL}`);

--- a/index.js
+++ b/index.js
@@ -31,12 +31,8 @@ userInput
     '-i, --ignore-local-bin',
     'Ignore any binaries in ./node_modules/.bin',
   )
-  .option(
-    '-v, --verbose',
-    'Prints information about all the binaries detected',
-  )
+  .option('-v, --verbose', 'Prints information about all the binaries detected')
   .parse(process.argv);
-
 
 if (!userInput.verbose) {
   console.log = () => {};

--- a/index.js
+++ b/index.js
@@ -54,9 +54,18 @@ const checkVersion = (engineName, command) => {
   let version = null;
 
   try {
-    const local_bin_folder = execSync('npm bin').toString().trim();
+    const localBinFolder = execSync('npm bin')
+      .toString()
+      .trim();
 
-    version = execSync(command, { env: { PATH: process.env.PATH.replace(`${local_bin_folder}${path.delimiter}`, '') } } )
+    version = execSync(command, {
+      env: {
+        PATH: process.env.PATH.replace(
+          `${localBinFolder}${path.delimiter}`,
+          '',
+        ),
+      },
+    })
       .toString()
       .replace('v', '')
       .trim();

--- a/index.js
+++ b/index.js
@@ -38,18 +38,14 @@ const checkVersion = (engineName, command) => {
     process.exit(1);
   }
 
-  let expected = null;
-
-  try {
-    expected = pkg.engines[engineName];
-  } catch (e) {
+  if (!pkg.engines || !pkg.engines[engineName]) {
     console.log(
       `There is no engine named "${engineName}" specified in package.json!  😱${EOL}`,
     );
     process.exit(1);
   }
 
-  let version = null;
+  const expected = pkg.engines[engineName];
 
   try {
     const localBinFolder = execSync('npm bin')

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ userInput
   .parse(process.argv);
 
 const getVersion = ({ command, localBinFolder, global = true }) => {
-  let env = { PATH: process.env.PATH };
+  const env = { PATH: process.env.PATH };
 
   if (global) {
     env.PATH = env.PATH.replace(`${localBinFolder}${path.delimiter}`, '');
@@ -72,7 +72,6 @@ const checkVersion = (engineName, command) => {
 
   const expected = pkg.engines[engineName];
 
-
   let globalVersion = null;
   let localVersion = null;
   let usedVersion = null;
@@ -95,7 +94,7 @@ const checkVersion = (engineName, command) => {
     console.log(
       `╰─ Global ${engineName} version:\t${globalVersion}\t${
         globalVersionValid ? '✅️' : '❌️'
-        }`,
+      }`,
     );
 
     if (hasLocalVersion) {

--- a/index.js
+++ b/index.js
@@ -54,7 +54,9 @@ const checkVersion = (engineName, command) => {
   let version = null;
 
   try {
-    version = execSync(command)
+    const local_bin_folder = execSync('npm bin').toString().trim();
+
+    version = execSync(command, { env: { PATH: process.env.PATH.replace(`${local_bin_folder}${path.delimiter}`, '') } } )
       .toString()
       .replace('v', '')
       .trim();

--- a/index.js
+++ b/index.js
@@ -31,7 +31,16 @@ userInput
     '-i, --ignore-local-bin',
     'Ignore any binaries in ./node_modules/.bin',
   )
+  .option(
+    '-v, --verbose',
+    'Prints information about all the binaries detected',
+  )
   .parse(process.argv);
+
+
+if (!userInput.verbose) {
+  console.log = () => {};
+}
 
 const getVersion = ({ command, localBinFolder, global = true }) => {
   const env = { PATH: process.env.PATH };
@@ -56,8 +65,8 @@ const checkVersion = (engineName, command) => {
     // eslint-disable-next-line global-require, import/no-dynamic-require
     pkg = require(pkgJsonPath);
   } catch (e) {
-    console.log(`Unable to find ${pkgJsonPath}!  😱${EOL}`);
-    console.log(
+    console.error(`Unable to find ${pkgJsonPath}!  😱${EOL}`);
+    console.error(
       `Please ensure that this script is executed in the same directory.${EOL}`,
     );
     process.exit(1);
@@ -115,26 +124,26 @@ const checkVersion = (engineName, command) => {
 
     console.log(`╰─ (using: ${usedVersion})${EOL}`);
   } catch (e) {
-    console.log(`Unable to get ${engineName} version!  😱${EOL}`);
+    console.error(`Unable to get ${engineName} version!  😱${EOL}`);
     process.exit(1);
   }
 
   if (!semver.satisfies(usedVersion, expected)) {
     const guide =
       'https://github.com/Skyscanner/ensure-node-env/blob/master/README.md#guide';
-    console.log(
+    console.error(
       `Expected ${engineName} version to match ${expected}, but got ${usedVersion}.  😱${EOL}`,
     );
-    console.log(
+    console.error(
       `Please follow Skyscanner's node environment guide (see ${guide}).${EOL}`,
     );
     process.exit(1);
   }
 };
 
-console.log(`Checking node & npm versions...${EOL}`);
+console.info(`Checking node & npm versions...${EOL}`);
 
 checkVersion('node', 'node --version');
 checkVersion('npm', 'npm -g --version');
 
-console.log(`${EOL}All good.  👍${EOL}`);
+console.info(`${EOL}All good.  👍${EOL}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -494,10 +494,9 @@
       "dev": true
     },
     "commander": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.18.0.tgz",
-      "integrity": "sha512-6CYPa+JP2ftfRU2qkDK+UTVeQYosOg/2GbcjIcKPHfinyOLPVGXu/ovN86RP49Re5ndJK1N0kuiidFFuepc4ZQ==",
-      "dev": true
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
     },
     "concat-map": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -38,5 +38,8 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "rollup-plugin-terser": "^3.0.0",
     "semver": "^5.5.1"
+  },
+  "dependencies": {
+    "commander": "^2.19.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,6 +2,10 @@ import { terser } from 'rollup-plugin-terser';
 import commonjs from 'rollup-plugin-commonjs';
 import resolve from 'rollup-plugin-node-resolve';
 
+// 'events' and 'util' are used by the 3rd party `commander` package
+const COMMON_IMPORTS = ['path', 'child_process', 'os', 'fs', 'events', 'util'];
+const COMMON_PLUGINS = [resolve(), commonjs(), terser()];
+
 export default [
   {
     input: 'index.js',
@@ -9,8 +13,8 @@ export default [
       file: 'dist/index.js',
       format: 'cjs',
     },
-    external: ['path', 'child_process', 'os', 'fs', 'events', 'util'],
-    plugins: [resolve(), commonjs(), terser()],
+    external: COMMON_IMPORTS,
+    plugins: COMMON_PLUGINS,
   },
   {
     input: 'index.js',
@@ -19,7 +23,7 @@ export default [
       format: 'cjs',
       banner: '#!/usr/bin/env node',
     },
-    external: ['path', 'child_process', 'os', 'fs', 'events', 'util'],
-    plugins: [resolve(), commonjs(), terser()],
+    external: COMMON_IMPORTS,
+    plugins: COMMON_PLUGINS,
   },
 ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,7 +9,7 @@ export default [
       file: 'dist/index.js',
       format: 'cjs',
     },
-    external: ['path', 'child_process'],
+    external: ['path', 'child_process', 'os', 'fs', 'events', 'util'],
     plugins: [resolve(), commonjs(), terser()],
   },
   {
@@ -19,7 +19,7 @@ export default [
       format: 'cjs',
       banner: '#!/usr/bin/env node',
     },
-    external: ['path', 'child_process'],
+    external: ['path', 'child_process', 'os', 'fs', 'events', 'util'],
     plugins: [resolve(), commonjs(), terser()],
   },
 ];


### PR DESCRIPTION
When running `ensure-node-env` after an initial `npm install`, a user may see errors like the following:

```Expected npm version to match ^6.4.1, but got 5.6.0```

..even when their `npm` version is correct. This is due to `npx` [prepending](https://github.com/zkat/npx/blob/latest/index.js#L120) the local `./node_modules/.bin` folder to the `PATH` environment variable, mirroring `npm`'s [behaviour](https://docs.npmjs.com/cli/run-script).

In turn, this means that if any other dependency in `package.json` depends on `npm` (for example, older versions of `oc` do), when `ensure-node-env` runs it will pick that one, because it will be symlinked in `./node_modules/.bin` and this folder will be first in the PATH.

As a workaround, this PR adds a new command-line parameter which allows to ignore binaries from the local `.bin` folder. No folder names are hardcoded (`npm bin` is used to determine the right path).

It should also work cross-platform, BUT I have only tested it on a Mac.

Besides, the PR also makes the command output more informative.
The screenshot below shows the output when using the new parameter.

![screen shot 2018-11-20 at 10 38 13](https://user-images.githubusercontent.com/1095044/48768462-001bf980-ecb1-11e8-8757-824bcf25f3f0.png)
 